### PR TITLE
Make sure retrieving telemetry data works in classic apps

### DIFF
--- a/lib/utils/telemetry.js
+++ b/lib/utils/telemetry.js
@@ -36,7 +36,8 @@ function getTelemetry() {
  */
 function getTelemetryFor(filePath) {
   let modulePath = getModulePathFor(filePath);
-  let data = getTelemetry()[modulePath];
+  let moduleKey = modulePath.replace('templates/components/', 'components/');
+  let data = getTelemetry()[moduleKey];
 
   return data;
 }

--- a/lib/utils/telemetry.test.js
+++ b/lib/utils/telemetry.test.js
@@ -26,4 +26,14 @@ describe('getTelemetryFor', () => {
 
     expect(value).toEqual(1);
   });
+
+  test('gets the data for the filePath in classic apps', () => {
+    let fakeTelemetry = { 'test-app/components/test-component': 1 };
+
+    setTelemetry(fakeTelemetry);
+
+    let value = getTelemetryFor('test-app/templates/components/test-component');
+
+    expect(value).toEqual(1);
+  });
 });


### PR DESCRIPTION
Pulled from my original fix in https://github.com/ember-codemods/ember-no-implicit-this-codemod/pull/9 for https://github.com/ember-codemods/ember-no-implicit-this-codemod/issues/7

From my original comment at https://github.com/ember-codemods/ember-no-implicit-this-codemod/issues/7#issuecomment-513369899

Classicly structured Ember apps are not being modified because retrieving the component telemetry data isn't working. Data is not retrieved because the key used doesn't match how it is stored.

**Key (module path to file being code-modded):** `test-app/templates/components/test-component`
**Telemetry hash key:** `test-app/components/test-component` 

The fix is simple in that I'm replacing `templates/components/` with `components/`. I tested this on the sample app from issue description and it worked.

I also noticed this conversation in the #topic-codemods Ember Discord channel, but I don't know enough about pod rules to put together a fix yet. Best to ship this version first.

![image](https://user-images.githubusercontent.com/685034/62712362-9ab09a00-b9f2-11e9-8ba9-e7f971d7fe97.png)

