### PR TITLE
Gather ES5 getter telemetry data

### DIFF
--- a/lib/gather/gather-telemetry.js
+++ b/lib/gather/gather-telemetry.js
@@ -64,6 +64,7 @@ module.exports = async function gatherTelemetry(url) {
      * @param {Object} meta
      * @returns {Object} data - Parsed metadata for the ember object
      * @returns {String[]} data.computedProperties - list of computed properties
+     * @returns {String[]} data.getters - list of ES5 getters
      * @returns {String[]} data.observedProperties - list of observed properties
      * @returns {Object} data.observerProperties - list of observer properties
      * @returns {Object} data.offProperties - list of observer properties
@@ -103,6 +104,11 @@ module.exports = async function gatherTelemetry(url) {
         }
       });
 
+      const ownDesc = Object.getOwnPropertyDescriptors(source);
+      const getters = Object.keys(ownDesc).filter(
+        key => ownDesc[key].get && !computedProperties.includes(key)
+      );
+
       const { offProperties, unobservedProperties } = ownProperties.reduce(
         ({ offProperties, unobservedProperties }, key) => {
           const { type, events } = getListenerData(meta.parent, key);
@@ -127,6 +133,7 @@ module.exports = async function gatherTelemetry(url) {
 
       return {
         computedProperties,
+        getters,
         observedProperties,
         observerProperties,
         offProperties,


### PR DESCRIPTION
Brings over the ES5 getter telemetry gathering aspect to here from https://github.com/ember-codemods/ember-no-implicit-this-codemod/pull/10

I wasn't exactly sure how this should be tested.