### PR TITLE
Support retrieving telemetry data for controllers in classic apps

### DIFF
--- a/lib/utils/telemetry.js
+++ b/lib/utils/telemetry.js
@@ -36,10 +36,16 @@ function getTelemetry() {
  */
 function getTelemetryFor(filePath) {
   let modulePath = getModulePathFor(filePath);
-  let moduleKey = modulePath.replace('templates/components/', 'components/');
+  let moduleKey = _generateModuleKey(modulePath);
   let data = getTelemetry()[moduleKey];
 
   return data;
+}
+
+function _generateModuleKey(modulePath) {
+  let moduleKey = modulePath.replace('templates/components/', 'components/');
+  // If `templates/` still exists in the path then it wasn't a component but a controller-level template instead
+  return moduleKey.replace('templates/', 'controllers/');
 }
 
 module.exports = {

--- a/lib/utils/telemetry.test.js
+++ b/lib/utils/telemetry.test.js
@@ -27,13 +27,25 @@ describe('getTelemetryFor', () => {
     expect(value).toEqual(1);
   });
 
-  test('gets the data for the filePath in classic apps', () => {
-    let fakeTelemetry = { 'test-app/components/test-component': 1 };
+  describe('classic apps', () => {
+    test('gets the data for the component filePath', () => {
+      let fakeTelemetry = { 'test-app/components/test-component': 1 };
 
-    setTelemetry(fakeTelemetry);
+      setTelemetry(fakeTelemetry);
 
-    let value = getTelemetryFor('test-app/templates/components/test-component');
+      let value = getTelemetryFor('test-app/templates/components/test-component');
 
-    expect(value).toEqual(1);
+      expect(value).toEqual(1);
+    });
+
+    test('gets the data for the controller filePath', () => {
+      let fakeTelemetry = { 'test-app/controllers/application': 1 };
+
+      setTelemetry(fakeTelemetry);
+
+      let value = getTelemetryFor('test-app/templates/application');
+
+      expect(value).toEqual(1);
+    });
   });
 });


### PR DESCRIPTION
Currently the [no-implicit-this codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod) doesn't support transforming controller-level templates because it can never find controller telemetry data for these templates.

For example, take the following:

``` hbs
{{!-- app/templates/application.hbs --}}
{{someValue}}
```

``` js
// app/controllers/application.js
import Controller from '@ember/controller';

export default Controller.extend({
  someValue: 'foo'
});
```

The `application.hbs` template is never transformed because the telemetry key is stored as `app/controllers/application` but the template file path is `app/templates/application`. To make these sync I transform `templates/` to `controllers/`.

