### PR TITLE
Fix `Cannot read property '1' of undefined` exception

### DIFF
--- a/lib/gather/gather-telemetry.js
+++ b/lib/gather/gather-telemetry.js
@@ -127,8 +127,11 @@ module.exports = async function gatherTelemetry(url) {
       );
 
       const observerProperties = observedProperties.reduce((acc, oProp) => {
-        const listener = meta.matchingListeners(`${oProp}:change`)[1];
-        acc[listener] = [].concat(acc[listener] || [], [oProp]);
+        const listenerData = meta.matchingListeners(`${oProp}:change`);
+        if (listenerData) {
+          const listener = listenerData[1];
+          acc[listener] = [].concat(acc[listener] || [], [oProp]);
+        }
         return acc;
       }, {});
 


### PR DESCRIPTION
In some cases the result returned from `meta.matchingListeners()` is `null`, in which case that exception is thrown.