### PR TITLE
Support referenced functions from within the gather function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 .next
 
 test/fixtures/classic-app/dist/
+lib/gather/cli.js

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ This package does provide one gathering function: `analyzeEmberObject`.  The fun
 const { analyzeEmberObject } = require('ember-codemods-telemetry-helpers');
 ```
 
+## Caveats
+If the gather function references functions defined outside of the the gather function body, all of those functions must be exported as well.  It is strongly suggested that the gather function be self contained, and if functions must be used (code maintainability/readability), that they be defined within the function.  If this is not possible, the `gatherTelemetryForUrl` has been enhanced to accept all functions that must go along with the gather function:
+
+```javascript
+gatherTelemetryForUrl(appLocation, gatherFunction, suppportFn1, suppportFn2, ..., puppeteerArgs);
+```
+
 ## Contributing
 
 ### Installation

--- a/lib/gather/analyze-ember-object.js
+++ b/lib/gather/analyze-ember-object.js
@@ -11,6 +11,101 @@ module.exports = function analyzeEmberObject(possibleEmberObject) {
   /* globals Ember */
   let meta = Ember.meta(proto);
 
+  /**
+   * Parses the ember meta with passed key
+   *
+   * @param {Ember.meta} map
+   * @param {String} key
+   * @returns {Object} meta - The listener meta data
+   * @returns {String} meta.type - Type of listener can be observer|event
+   * @returns {String[]} meta.events - name of events/properties the listener is registered on
+   */
+  let getListenerData = (map, key) => {
+    while (map) {
+      let type = 'event';
+      const events = parseListeners(map._listeners).reduce((acc, [event, , method]) => {
+        if (method === key) {
+          const [observedProp, observerEvent] = event.split(':');
+          if (observerEvent) {
+            type = 'observer';
+          }
+          acc.push(observedProp);
+        }
+        return acc;
+      }, []);
+      if (events.length) {
+        return {
+          type,
+          events,
+        };
+      }
+      map = map.parent;
+    }
+    return {};
+  };
+
+  /**
+   * Checks if passed key is overriding any value from the parent objects
+   *
+   * @param {Object} map
+   * @param {String} key
+   * @returns boolean
+   */
+  let isOverridden = (map, key) => {
+    while (map) {
+      const value = map.peekValues ? map.peekValues(key) : undefined;
+      if (value !== undefined || (map.source && key in map.source)) {
+        return true;
+      }
+      map = map.parent;
+    }
+    return false;
+  };
+
+  /**
+   * Parse the listeners to a group of array of 4 elements
+   *
+   * @param {Array} listeners
+   * @param {int} size
+   * @returns Array
+   */
+  let parseListeners = (listeners = [], size = 4) => {
+    var result = [];
+    if (listeners.length) {
+      if (typeof listeners[0] === 'object') {
+        result = listeners.map(({ event, target, method, kind }) => [event, target, method, kind]);
+      } else {
+        const input = listeners.slice(0);
+        while (input.length) {
+          result.push(input.splice(0, size));
+        }
+      }
+    }
+    return result;
+  };
+
+  /**
+   * Checks if passed key is overriding any value from the parent objects' actions
+   *
+   * @param {Object} map
+   * @param {String} key
+   * @returns boolean
+   */
+  let isActionOverridden = (map, key) => {
+    while (map) {
+      const { source } = map;
+      if (source) {
+        const { actions } = source;
+        const value = actions ? actions[key] : undefined;
+        if (value !== undefined) {
+          return true;
+        }
+      }
+      map = map.parent;
+    }
+    return false;
+  };
+
   // eslint-disable-next-line no-undef
   if (!meta || !meta.source) {
     return {};
@@ -112,98 +207,3 @@ module.exports = function analyzeEmberObject(possibleEmberObject) {
     unobservedProperties,
   };
 };
-
-/**
- * Parses the ember meta with passed key
- *
- * @param {Ember.meta} map
- * @param {String} key
- * @returns {Object} meta - The listener meta data
- * @returns {String} meta.type - Type of listener can be observer|event
- * @returns {String[]} meta.events - name of events/properties the listener is registered on
- */
-function getListenerData(map, key) {
-  while (map) {
-    let type = 'event';
-    const events = parseListeners(map._listeners).reduce((acc, [event, , method]) => {
-      if (method === key) {
-        const [observedProp, observerEvent] = event.split(':');
-        if (observerEvent) {
-          type = 'observer';
-        }
-        acc.push(observedProp);
-      }
-      return acc;
-    }, []);
-    if (events.length) {
-      return {
-        type,
-        events,
-      };
-    }
-    map = map.parent;
-  }
-  return {};
-}
-
-/**
- * Parse the listeners to a group of array of 4 elements
- *
- * @param {Array} listeners
- * @param {int} size
- * @returns Array
- */
-function parseListeners(listeners = [], size = 4) {
-  var result = [];
-  if (listeners.length) {
-    if (typeof listeners[0] === 'object') {
-      result = listeners.map(({ event, target, method, kind }) => [event, target, method, kind]);
-    } else {
-      const input = listeners.slice(0);
-      while (input.length) {
-        result.push(input.splice(0, size));
-      }
-    }
-  }
-  return result;
-}
-
-/**
- * Checks if passed key is overriding any value from the parent objects
- *
- * @param {Object} map
- * @param {String} key
- * @returns boolean
- */
-function isOverridden(map, key) {
-  while (map) {
-    const value = map.peekValues ? map.peekValues(key) : undefined;
-    if (value !== undefined || (map.source && key in map.source)) {
-      return true;
-    }
-    map = map.parent;
-  }
-  return false;
-}
-
-/**
- * Checks if passed key is overriding any value from the parent objects' actions
- *
- * @param {Object} map
- * @param {String} key
- * @returns boolean
- */
-function isActionOverridden(map, key) {
-  while (map) {
-    const { source } = map;
-    if (source) {
-      const { actions } = source;
-      const value = actions ? actions[key] : undefined;
-      if (value !== undefined) {
-        return true;
-      }
-    }
-    map = map.parent;
-  }
-  return false;
-}

--- a/lib/gather/gather-telemetry.js
+++ b/lib/gather/gather-telemetry.js
@@ -3,7 +3,15 @@ const { setTelemetry } = require('../utils/telemetry');
 
 const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true };
 
-module.exports = async function gatherTelemetry(url, gatherFn, puppeteerArgs = {}) {
+module.exports = async function gatherTelemetry(url, gatherFn, ...args) {
+  let puppeteerArgs = [...args].pop();
+  let supportFns = args;
+
+  if (typeof puppeteerArgs === 'object') {
+    supportFns.pop();
+  } else {
+    puppeteerArgs = {};
+  }
   Object.assign(puppeteerArgs, DEFAULT_PUPPETEER_ARGS);
 
   const browser = await puppeteer.launch(puppeteerArgs);
@@ -17,7 +25,11 @@ module.exports = async function gatherTelemetry(url, gatherFn, puppeteerArgs = {
 
   const telemetry = await bridgeEvaluate(
     page,
-    async gFn => {
+    async (gFn, ...supportFns) => {
+      supportFns.forEach(fn => {
+        this[fn.name] = fn;
+      });
+
       const SKIPPED_MODULES = ['fetch/ajax'];
       /* globals window,*/
       let telemetry = {};
@@ -38,7 +50,8 @@ module.exports = async function gatherTelemetry(url, gatherFn, puppeteerArgs = {
       }
       return telemetry;
     },
-    gatherFn
+    gatherFn,
+    ...supportFns
   );
 
   setTelemetry(telemetry);

--- a/lib/gather/gather-telemetry.test.js
+++ b/lib/gather/gather-telemetry.test.js
@@ -37,7 +37,7 @@ describe('Provide a personalized `Gathering Function`', () => {
   test('can determine components with a robust function', async () => {
     await gatherTelemetry('http://localhost:4200', analyzeEmberObject);
     let telemetry = getTelemetry();
-    expect(Object.keys(telemetry).filter(Boolean).length).toEqual(1);
+    expect(Object.keys(telemetry).filter(Boolean).length).toEqual(29);
   });
 
   afterAll(async () => {

--- a/lib/gather/gather-telemetry.test.js
+++ b/lib/gather/gather-telemetry.test.js
@@ -14,6 +14,18 @@ function helper(possibleEmberObject) {
   }
 }
 
+function outer(possibleEmberObject) {
+  let obj = possibleEmberObject.default;
+  if (obj && obj.name) {
+    return obj.name === 'jQuery';
+  }
+  return false;
+}
+
+function inner(possibleEmberObject) {
+  return outer(possibleEmberObject);
+}
+
 describe('Provide a personalized `Gathering Function`', () => {
   let app;
   let localAppPath = './test/fixtures/classic-app';
@@ -37,7 +49,13 @@ describe('Provide a personalized `Gathering Function`', () => {
   test('can determine components with a robust function', async () => {
     await gatherTelemetry('http://localhost:4200', analyzeEmberObject);
     let telemetry = getTelemetry();
-    expect(Object.keys(telemetry).filter(Boolean).length).toEqual(29);
+    expect(Object.values(telemetry).filter(Boolean).length).toEqual(29);
+  });
+
+  test('can handle external functions', async () => {
+    await gatherTelemetry('http://localhost:4200', inner, outer);
+    let telemetry = getTelemetry();
+    expect(Object.values(telemetry).filter(Boolean).length).toEqual(1);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
This PR:

1. fixes `analyzeEmberObject` to be one function, inlining the other functions it required.
2. Enhances `gatherTelemetryForUrl` to take any number of functions to support a gathering function that references function outside of its body

Partially fixes #19 