### PR TITLE
Enumerate Component templates.

### DIFF
--- a/lib/gather/analyze-ember-object.js
+++ b/lib/gather/analyze-ember-object.js
@@ -1,4 +1,6 @@
-module.exports = function analyzeEmberObject(possibleEmberObject) {
+module.exports = function analyzeEmberObject(possibleEmberObject, modulePath) {
+  let isTemplate = false;
+
   if (typeof possibleEmberObject !== 'object' || possibleEmberObject === null) {
     return undefined;
   }
@@ -10,6 +12,18 @@ module.exports = function analyzeEmberObject(possibleEmberObject) {
         type: 'Helper',
       };
     } else if (typeof eObjDefault.proto !== 'function') {
+      /**
+       * this is for JavaScript-less components that only have a template. Only
+       * components with a backing JavaScript file will be in the `require.entries`
+       * that will have a `proto()` we can instantiate.
+       */
+      if (modulePath && modulePath.includes('templates/components/')) {
+        isTemplate = true;
+        return {
+          isTemplate,
+          type: 'Component',
+        };
+      }
       return undefined;
     }
   }

--- a/lib/gather/gather-telemetry.js
+++ b/lib/gather/gather-telemetry.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 const { setTelemetry } = require('../utils/telemetry');
 
-const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true };
+const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true, devtools: true };
 
 module.exports = async function gatherTelemetry(url, gatherFn, ...args) {
   let puppeteerArgs = [...args].pop();
@@ -42,7 +42,7 @@ module.exports = async function gatherTelemetry(url, gatherFn, ...args) {
 
         try {
           let module = require(modulePath);
-          telemetry[modulePath] = await gFn(module);
+          telemetry[modulePath] = await gFn(module, modulePath);
         } catch (error) {
           // log the error, but continue
           window.logErrorInNodeProcess(`error evaluating \`${modulePath}\`: ${error.message}`);

--- a/lib/gather/gather-telemetry.js
+++ b/lib/gather/gather-telemetry.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 const { setTelemetry } = require('../utils/telemetry');
 
-const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true, devtools: true };
+const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true };
 
 module.exports = async function gatherTelemetry(url, gatherFn, ...args) {
   let puppeteerArgs = [...args].pop();

--- a/lib/gather/gather-telemetry.test.js
+++ b/lib/gather/gather-telemetry.test.js
@@ -49,13 +49,22 @@ describe('Provide a personalized `Gathering Function`', () => {
   test('can determine most Ember types with a robust function', async () => {
     await gatherTelemetry('http://localhost:4200', analyzeEmberObject);
     let telemetry = getTelemetry();
-    expect(Object.values(telemetry).filter(Boolean).length).toEqual(34);
+    expect(Object.values(telemetry).filter(Boolean).length).toEqual(38);
   });
 
   test('can handle external functions', async () => {
     await gatherTelemetry('http://localhost:4200', inner, outer);
     let telemetry = getTelemetry();
     expect(Object.values(telemetry).filter(Boolean).length).toEqual(1);
+  });
+
+  test('can enumerate template only classic components', async () => {
+    await gatherTelemetry('http://localhost:4200', analyzeEmberObject);
+    let telemetry = getTelemetry();
+    let components = Object.values(telemetry).filter(obj => obj.isTemplate);
+    expect(components.length).toEqual(4);
+    expect(components[0].type).toEqual('Component');
+    expect(components[0].isTemplate).toBe(true);
   });
 
   afterAll(async () => {

--- a/test/fixtures/classic-app/app/templates/components/no-script-component.hbs
+++ b/test/fixtures/classic-app/app/templates/components/no-script-component.hbs
@@ -1,0 +1,3 @@
+<div>
+  <p>I have no JavaScript class</p>
+</div>


### PR DESCRIPTION
Reason - this is for JavaScript-less components that only have a template. Only components with a backing JavaScript file will be in the `require.entries` that will have a `proto()` we can instantiate.

This PR returns the template as type `Component` but adds a new property `isTemplate` so that it can be distinguished as a `Component Template`