### PR TITLE
Fix colon character in cwd on Windows

### DIFF
--- a/lib/gather/cache.js
+++ b/lib/gather/cache.js
@@ -1,11 +1,15 @@
 const Cache = require('sync-disk-cache');
 const getRepoInfo = require('git-repo-info');
+const crypto = require('crypto');
 
 const gitInfo = getRepoInfo();
 
-const cwd = process.cwd().replace(':', '꞉');
+const cwdHash = crypto
+  .createHash('sha256')
+  .update(process.cwd(), 'utf8')
+  .digest('hex');
 
-const cachePath = `ember-codemods-telemetry-helpers-${gitInfo.sha}-${cwd}`;
+const cachePath = `ember-codemods-telemetry-helpers-${gitInfo.sha}-${cwdHash}`;
 
 const cache = new Cache(cachePath);
 

--- a/lib/gather/cache.js
+++ b/lib/gather/cache.js
@@ -3,7 +3,10 @@ const getRepoInfo = require('git-repo-info');
 
 const gitInfo = getRepoInfo();
 
-const cachePath = `ember-codemods-telemetry-helpers-${gitInfo.sha}-${process.cwd()}`;
+const cwd = process.cwd().replace(':', '꞉');
+
+const cachePath = `ember-codemods-telemetry-helpers-${gitInfo.sha}-${cwd}`;
+
 const cache = new Cache(cachePath);
 
 module.exports = cache;


### PR DESCRIPTION
On Windows colon character is [not allowed](https://docs.microsoft.com/tr-tr/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#file_and_directory_names). Therefor it shouldn't be used on any filename.

This fix simply changes colon character with unicode [equivalent](https://stackoverflow.com/a/25477235/2087505) and fixes **Error: EINVAL: invalid argument, mkdir** error on Windows.

Thank you.