### PR TITLE
Add single telemetry support

### DIFF
--- a/lib/gather/gather-single-telemetry.js
+++ b/lib/gather/gather-single-telemetry.js
@@ -1,9 +1,9 @@
 const puppeteer = require('puppeteer');
-const { setTelemetry, getTelemetry } = require('../utils/telemetry');
+const { setTelemetryWithKey } = require('../utils/telemetry');
 
 const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true };
 
-module.exports = async function gatherSingleTelemetry(url, gatherFn, ...args) {
+module.exports = async function gatherSingleTelemetry(url, options = {}, gatherFn, ...args) {
   const browser = await puppeteer.launch(DEFAULT_PUPPETEER_ARGS);
   const page = await browser.newPage();
 
@@ -28,10 +28,7 @@ module.exports = async function gatherSingleTelemetry(url, gatherFn, ...args) {
     ...args
   );
 
-  // get the current telemetry and add the `single-telemetry` key to it.
-  const currentTelemetry = getTelemetry();
-  currentTelemetry['single-telemetry'] = telemetry;
-  setTelemetry(currentTelemetry);
+  setTelemetryWithKey(options.telemetryKey, telemetry);
   await browser.close();
 
   async function bridgeEvaluate(page, fn, ...rawArgs) {

--- a/lib/gather/gather-single-telemetry.js
+++ b/lib/gather/gather-single-telemetry.js
@@ -1,0 +1,45 @@
+const puppeteer = require('puppeteer');
+const { setTelemetry, getTelemetry } = require('../utils/telemetry');
+
+const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true };
+
+module.exports = async function gatherSingleTelemetry(url, gatherFn, ...args) {
+  const browser = await puppeteer.launch(DEFAULT_PUPPETEER_ARGS);
+  const page = await browser.newPage();
+
+  await page.goto(url);
+
+  await page.exposeFunction('logErrorInNodeProcess', message => {
+    console.error(message); // eslint-disable-line no-console
+  });
+
+  const telemetry = await bridgeEvaluate(
+    page,
+    async (gFn, ...supportFns) => {
+      supportFns.forEach(fn => {
+        this[fn.name] = fn;
+      });
+      let telemetry = {};
+
+      telemetry = await gFn(...supportFns);
+      return telemetry;
+    },
+    gatherFn,
+    ...args
+  );
+
+  // get the current telemetry and add the `single-telemetry` key to it.
+  const currentTelemetry = getTelemetry();
+  currentTelemetry['single-telemetry'] = telemetry;
+  setTelemetry(currentTelemetry);
+  await browser.close();
+
+  async function bridgeEvaluate(page, fn, ...rawArgs) {
+    const args = await Promise.all(
+      rawArgs.map(arg => {
+        return typeof arg === 'function' ? page.evaluateHandle(`(${arg.toString()})`) : arg;
+      })
+    );
+    return page.evaluate(fn, ...args);
+  }
+};

--- a/lib/gather/gather-single-telemetry.test.js
+++ b/lib/gather/gather-single-telemetry.test.js
@@ -1,0 +1,51 @@
+const startApp = require('../../test/helpers/start-app');
+const gatherSingleTelemetry = require('./gather-single-telemetry');
+const { getTelemetry } = require('../utils/telemetry');
+const APP_TIMEOUT = 100000;
+
+function resolverWithoutArgs() {
+  return { foo: 'bar' };
+}
+
+function resolverWithArgs(lookupNames) {
+  if (lookupNames) {
+    return lookupNames.map(item => {
+      const lookupSplit = item.split(':');
+      return { name: lookupSplit[1], type: lookupSplit[0] };
+    });
+  }
+}
+
+describe('Gather single telemetry', () => {
+  let app;
+  let localAppPath = './test/fixtures/classic-app';
+  beforeAll(async () => {
+    app = await startApp(localAppPath);
+    console.log(`Spawned PID: ${app.emberServe.pid}`);
+  }, APP_TIMEOUT);
+
+  test('can determine base single telemetry case', async () => {
+    await gatherSingleTelemetry('http://localhost:4200', resolverWithoutArgs);
+    let telemetry = getTelemetry();
+    expect(telemetry['single-telemetry']).toEqual({
+      foo: 'bar',
+    });
+  });
+
+  test('can determine single telemetry with arguments passed', async () => {
+    const lookupNames = ['component:foo', 'helper:bar'];
+    await gatherSingleTelemetry('http://localhost:4200', resolverWithArgs, lookupNames);
+    let telemetry = getTelemetry();
+    expect(telemetry['single-telemetry']).toEqual([
+      { name: 'foo', type: 'component' },
+      { name: 'bar', type: 'helper' },
+    ]);
+  });
+
+  afterAll(async () => {
+    console.log(`Killing PID: ${app.emberServe.pid}`);
+    await app.emberServe.kill('SIGTERM', {
+      forceKillAfterTimeout: 200,
+    });
+  }, APP_TIMEOUT);
+});

--- a/lib/gather/gather-single-telemetry.test.js
+++ b/lib/gather/gather-single-telemetry.test.js
@@ -54,8 +54,6 @@ describe('Gather single telemetry', () => {
 
   afterAll(async () => {
     console.log(`Killing PID: ${app.emberServe.pid}`);
-    await app.emberServe.kill('SIGTERM', {
-      forceKillAfterTimeout: 200,
-    });
+    await app.emberServe.shutdown();
   }, APP_TIMEOUT);
 });

--- a/lib/gather/gather-single-telemetry.test.js
+++ b/lib/gather/gather-single-telemetry.test.js
@@ -2,6 +2,7 @@ const startApp = require('../../test/helpers/start-app');
 const gatherSingleTelemetry = require('./gather-single-telemetry');
 const { getTelemetry } = require('../utils/telemetry');
 const APP_TIMEOUT = 100000;
+const TELEMETRY_KEY = 'single-telemetry';
 
 function resolverWithoutArgs() {
   return { foo: 'bar' };
@@ -25,18 +26,27 @@ describe('Gather single telemetry', () => {
   }, APP_TIMEOUT);
 
   test('can determine base single telemetry case', async () => {
-    await gatherSingleTelemetry('http://localhost:4200', resolverWithoutArgs);
-    let telemetry = getTelemetry();
-    expect(telemetry['single-telemetry']).toEqual({
+    await gatherSingleTelemetry(
+      'http://localhost:4200',
+      { telemetryKey: TELEMETRY_KEY },
+      resolverWithoutArgs
+    );
+    let telemetry = getTelemetry(TELEMETRY_KEY);
+    expect(telemetry).toEqual({
       foo: 'bar',
     });
   });
 
   test('can determine single telemetry with arguments passed', async () => {
     const lookupNames = ['component:foo', 'helper:bar'];
-    await gatherSingleTelemetry('http://localhost:4200', resolverWithArgs, lookupNames);
-    let telemetry = getTelemetry();
-    expect(telemetry['single-telemetry']).toEqual([
+    await gatherSingleTelemetry(
+      'http://localhost:4200',
+      { telemetryKey: TELEMETRY_KEY },
+      resolverWithArgs,
+      lookupNames
+    );
+    let telemetry = getTelemetry(TELEMETRY_KEY);
+    expect(telemetry).toEqual([
       { name: 'foo', type: 'component' },
       { name: 'bar', type: 'helper' },
     ]);

--- a/lib/gather/gather-telemetry.test.js
+++ b/lib/gather/gather-telemetry.test.js
@@ -69,8 +69,6 @@ describe('Provide a personalized `Gathering Function`', () => {
 
   afterAll(async () => {
     console.log(`Killing PID: ${app.emberServe.pid}`);
-    await app.emberServe.kill('SIGTERM', {
-      forceKillAfterTimeout: 200,
-    });
+    await app.emberServe.shutdown();
   }, APP_TIMEOUT);
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const gatherTelemetryForUrl = require('./gather/gather-telemetry');
+const gatherSingleTelemetryForUrl = require('./gather/gather-single-telemetry.js');
 const { getModulePathFor } = require('./utils/get-module-path-for');
 const { getTelemetry, setTelemetry, getTelemetryFor } = require('./utils/telemetry');
 const analyzeEmberObject = require('./gather/analyze-ember-object');
@@ -7,6 +8,7 @@ module.exports = {
   getTelemetry,
   setTelemetry,
   gatherTelemetryForUrl,
+  gatherSingleTelemetryForUrl,
   getTelemetryFor,
   getModulePathFor,
   analyzeEmberObject,

--- a/lib/utils/telemetry.js
+++ b/lib/utils/telemetry.js
@@ -4,19 +4,23 @@ const { getModulePathFor } = require('./get-module-path-for');
 const CACHE_KEY = 'telemetry';
 
 function setTelemetry(newTelemetry) {
-  let data = JSON.stringify(newTelemetry);
-
-  cache.set(CACHE_KEY, data);
+  setTelemetryWithKey(CACHE_KEY, newTelemetry);
 }
 
-function getTelemetry() {
-  let telemetryExists = cache.has(CACHE_KEY);
+function setTelemetryWithKey(cacheKey, newTelemetry) {
+  let data = JSON.stringify(newTelemetry);
+  cache.set(cacheKey, data);
+}
+
+function getTelemetry(cacheKey) {
+  cacheKey = cacheKey || CACHE_KEY;
+  let telemetryExists = cache.has(cacheKey);
 
   if (!telemetryExists) {
     return {};
   }
 
-  let telemetryData = cache.get(CACHE_KEY).value;
+  let telemetryData = cache.get(cacheKey).value;
   let telemetry = {};
 
   try {
@@ -51,5 +55,6 @@ function _generateModuleKey(modulePath) {
 module.exports = {
   getTelemetry,
   setTelemetry,
+  setTelemetryWithKey,
   getTelemetryFor,
 };

--- a/lib/utils/telemetry.test.js
+++ b/lib/utils/telemetry.test.js
@@ -1,4 +1,4 @@
-const { getTelemetry, setTelemetry, getTelemetryFor } = require('./telemetry');
+const { getTelemetry, setTelemetry, setTelemetryWithKey, getTelemetryFor } = require('./telemetry');
 
 describe('get/set Telemetry', () => {
   test('can get the set telemetry', () => {
@@ -10,6 +10,22 @@ describe('get/set Telemetry', () => {
     setTelemetry(fakeTelemetry);
 
     let telemetry = getTelemetry();
+
+    expect(Object.keys(telemetry)).toEqual(Object.keys(fakeTelemetry));
+    expect(Object.values(telemetry)).toEqual(Object.values(fakeTelemetry));
+  });
+});
+
+describe('get/set Telemetry with keys', () => {
+  test('can get the set telemetry with keys', () => {
+    let fakeTelemetry = {
+      a: 1,
+      b: 2,
+    };
+
+    setTelemetryWithKey('fake-telemetry', fakeTelemetry);
+
+    let telemetry = getTelemetry('fake-telemetry');
 
     expect(Object.keys(telemetry)).toEqual(Object.keys(fakeTelemetry));
     expect(Object.values(telemetry)).toEqual(Object.values(fakeTelemetry));

--- a/test/helpers/start-app.js
+++ b/test/helpers/start-app.js
@@ -3,14 +3,14 @@ const path = require('path');
 
 module.exports = async function startApp(appPath) {
   const classicAppDir = path.resolve(appPath);
-  const execOpts = { cwd: classicAppDir, stderr: 'inherit' };
+  const execOpts = { cwd: classicAppDir, stderr: 'inherit', preferLocal: true };
   console.log('installing deps');
 
   await execa('rm', ['-rf', 'node_modules'], execOpts);
   await execa('yarn', ['install'], execOpts);
 
   console.log('starting serve');
-  const emberServe = execa('yarn', ['start'], execOpts);
+  const emberServe = execa('ember', ['serve'], execOpts);
   emberServe.stdout.pipe(process.stdout);
 
   await new Promise(resolve => {
@@ -21,6 +21,18 @@ module.exports = async function startApp(appPath) {
       }
     });
   });
+
+  emberServe.shutdown = async function() {
+    this.kill();
+    try {
+      await this;
+    } catch (e) {
+      // Process is allowed to exit with a non zero exit status code.
+    }
+    if (!this.killed) {
+      throw new Error(`the process ${this.pid} wasn't killed.`);
+    }
+  };
 
   return { emberServe };
 };

--- a/test/helpers/start-app.js
+++ b/test/helpers/start-app.js
@@ -10,6 +10,10 @@ module.exports = async function startApp(appPath) {
   await execa('yarn', ['install'], execOpts);
 
   console.log('starting serve');
+
+  // `yarn` has a bug where even if the process gets killed, it leaves the child process (ember in this case) orphaned.
+  // Hence we are using `ember` directly here to overcome the above shortcoming and ensure that the ember process is always killed
+  // cleanly.
   const emberServe = execa('ember', ['serve'], execOpts);
   emberServe.stdout.pipe(process.stdout);
 
@@ -28,9 +32,6 @@ module.exports = async function startApp(appPath) {
       await this;
     } catch (e) {
       // Process is allowed to exit with a non zero exit status code.
-    }
-    if (!this.killed) {
-      throw new Error(`the process ${this.pid} wasn't killed.`);
     }
   };
 


### PR DESCRIPTION
Currently, when we do `gatherTelemetryForUrl`, it runs the `analyzeEmberObject` or any custom resolver for every modulePath, which might be necessary where we want all sort of information for each module, but for cases where we might not need to call the resolver for each module, we could simply gather the required info all in one go.
This PR adds support for running the `telemetry` just once and store it in the `single-telemetry` key of the `telemetry` object.