### PR TITLE
Update `DEFAULT_PUPPETEER_ARGS` to launch Chrome with the `--no-sandbox` argument

### DIFF
--- a/lib/gather/gather-telemetry.js
+++ b/lib/gather/gather-telemetry.js
@@ -1,7 +1,10 @@
 const puppeteer = require('puppeteer');
 const { setTelemetry } = require('../utils/telemetry');
 
-const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] };
+const DEFAULT_PUPPETEER_ARGS = {
+  ignoreHTTPSErrors: true,
+  args: ['--no-sandbox', '--disable-setuid-sandbox'],
+};
 
 module.exports = async function gatherTelemetry(url, gatherFn, ...args) {
   let puppeteerArgs = [...args].pop();

--- a/lib/gather/gather-telemetry.js
+++ b/lib/gather/gather-telemetry.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 const { setTelemetry } = require('../utils/telemetry');
 
-const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true };
+const DEFAULT_PUPPETEER_ARGS = { ignoreHTTPSErrors: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] };
 
 module.exports = async function gatherTelemetry(url, gatherFn, ...args) {
   let puppeteerArgs = [...args].pop();


### PR DESCRIPTION
While running ember-native-class-codemod in a docker container (which is used by developers as a remote dev environment), it tries to use the sandbox even when we provide the chrome executable path using PUPPETEER_EXECUTABLE_PATH env.

As per the troubleshooting guide in the error - https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox, it suggests that we can set the `--no-sandbox` argument when we trust the contents that we open in chrome.

Hence adding ['--no-sandbox', '--disable-setuid-sandbox'] to the default puppeteer args.