### PR TITLE
prefer addon.moduleName as telemetry if one exists, otherwise fallback to packageName

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 2017
+    ecmaVersion: 2019
   },
   env: {
     node: true,

--- a/lib/utils/get-module-path-for.js
+++ b/lib/utils/get-module-path-for.js
@@ -32,16 +32,22 @@ for (let packagePath of packagePaths) {
  * @returns {String} The runtime name of the addon
  */
 function getAddonPackageName(packagePath) {
-  const indexPath = path.resolve(path.dirname(packagePath), 'index.js');
+  const pkg = require(packagePath);
+  const entryPoint = pkg['ember-addon'] && pkg['ember-addon'].main
+    ? pkg['ember-addon'].main
+    : 'index.js';
 
-  if (fs.existsSync(indexPath)) {
-    const { name: packageName, moduleName } = require(indexPath);
-    // this is bad, fix later
-    return moduleName && typeof moduleName === 'function' ? moduleName() : packageName;
+  let moduleName = pkg.name;
+  try {
+    let entryModule = require(path.join(packagePath, entryPoint));
+    if (typeof entryModule.moduleName === 'function') {
+      moduleName = entryModule.moduleName();
+    }
+  } catch {
+    // do nothing, this falls back to using package name
   }
-
-  const { name: packageName } = require(packagePath);
-  return packageName;
+  
+  return moduleName;
 }
 
 function isEmberCliProject(pkg) {

--- a/lib/utils/get-module-path-for.js
+++ b/lib/utils/get-module-path-for.js
@@ -33,9 +33,8 @@ for (let packagePath of packagePaths) {
  */
 function getAddonPackageName(packagePath) {
   const pkg = require(packagePath);
-  const entryPoint = pkg['ember-addon'] && pkg['ember-addon'].main
-    ? pkg['ember-addon'].main
-    : 'index.js';
+  const entryPoint =
+    pkg['ember-addon'] && pkg['ember-addon'].main ? pkg['ember-addon'].main : 'index.js';
 
   let moduleName = pkg.name;
   try {
@@ -46,7 +45,7 @@ function getAddonPackageName(packagePath) {
   } catch {
     // do nothing, this falls back to using package name
   }
-  
+
   return moduleName;
 }
 

--- a/lib/utils/get-module-path-for.js
+++ b/lib/utils/get-module-path-for.js
@@ -18,10 +18,30 @@ for (let packagePath of packagePaths) {
   let packageDir = path.dirname(path.resolve(cwd, packagePath));
 
   if (pkg.keywords && pkg.keywords.includes('ember-addon')) {
-    ADDON_PATHS[packageDir] = pkg.name;
+    // build addon instance
+    ADDON_PATHS[packageDir] = getAddonPackageName(packagePath);
   } else if (isEmberCliProject(pkg)) {
     APP_PATHS[packageDir] = pkg.name;
   }
+}
+
+/**
+ * takes a package path and returns the runtime name of the addon.
+ *
+ * @param {String} packagePath the path on disk (from current working directory)
+ * @returns {String} The runtime name of the addon
+ */
+function getAddonPackageName(packagePath) {
+  const indexPath = path.resolve(path.dirname(packagePath), 'index.js');
+
+  if (fs.existsSync(indexPath)) {
+    const { name: packageName, moduleName } = require(indexPath);
+    // this is bad, fix later
+    return moduleName && typeof moduleName === 'function' ? moduleName() : packageName;
+  }
+
+  const { name: packageName } = require(packagePath);
+  return packageName;
 }
 
 function isEmberCliProject(pkg) {


### PR DESCRIPTION
fixes #37.

if the codemod telemetry helpers are being run from inside of an ember-addon, prefer to use the addon's moduleName if it exists, otherwise fallback to the package name from package.json.

This is important as many packages now use npm's scoped package feature, which allows you to create packages like `@company/package-name`. In ember-land, these packages need to have a different module name (in this case, just `package-name`, as the @ syntax breaks handlebars invocation of templates from this package (ex: `<@Company/Package-Name />` )